### PR TITLE
Tests for "First" and "Any" added

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,7 @@ var (
 	TestDbName     = ""
 	TestUsername   = ""
 	TestPassword   = ""
+	TestString     = "test string"
 	verbose        = false
 	TestServer     = "http://localhost:8529"
 	s              *Session

--- a/simple_test.go
+++ b/simple_test.go
@@ -21,16 +21,22 @@ func TestSimple(t *testing.T) {
 	c := db.Col(TestCollection)
 	assert.NotNil(t, c)
 
+	// Save
+	var saveTestDoc DocTest
+	saveTestDoc.Text = TestString
+	err = c.Save(saveTestDoc)
+	assert.Nil(t, err)
+
 	// Any
 	err = c.Any(&TestDoc)
 	assert.Equal(t, TestDoc.Error, false)
-	assert.Nil(t, err)
+	assert.Equal(t, TestString, TestDoc.Text)
 
-	// Save
-	var saveTestDoc DocTest
-	saveTestDoc.Text = "Stringy string"
-	err = c.Save(saveTestDoc)
-	assert.Nil(t, err)
+	// First
+	TestDoc = DocTest{} // Clean TestDoc variable
+	err = c.First(map[string]interface{}{"Text": TestString}, &TestDoc)
+	assert.Equal(t, TestDoc.Error, false)
+	assert.Equal(t, TestString, TestDoc.Text)
 
 	// Example
 	cur, err := c.Example(map[string]interface{}{}, 0, 10)
@@ -38,10 +44,10 @@ func TestSimple(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, cur)
 
-	var newTestDoc DocTest
-	moreFiles := cur.FetchOne(&newTestDoc)
+	TestDoc = DocTest{} // Clean TestDoc variable
+	moreFiles := cur.FetchOne(&TestDoc)
 	assert.Equal(t, moreFiles, false)
-	assert.Equal(t, saveTestDoc.Text, newTestDoc.Text)
+	assert.Equal(t, TestString, TestDoc.Text)
 
 	// need to add new functions!
 


### PR DESCRIPTION
This commit adds a tests for `First` and `Any` that check the returned document (variable). This tests are failing (#5) and I'm going to start looking into it. 
Also, I think we need to document the fact that you cannot test until you add database and collection names in the test configuration (or add something to warn the user if the variables are empty).
