### PR TITLE
Fixed broken Graph() result when graph does exist.

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -2,11 +2,11 @@ package aranGO
 
 // Configure to start testing
 var (
-	TestCollection = ""
+	TestCollection = "TestCollection"
 	TestDoc        DocTest
-	TestDbName     = ""
-	TestUsername   = ""
-	TestPassword   = ""
+	TestDbName     = "TestDbName"
+	TestUsername   = "TestUsername"
+	TestPassword   = "TestPassword"
 	TestString     = "test string"
 	verbose        = false
 	TestServer     = "http://localhost:8529"

--- a/graph.go
+++ b/graph.go
@@ -509,8 +509,8 @@ func (db *Database) Graph(name string) *Graph {
 	if name == "" {
 		return nil
 	}
-	_, err := db.get("gharial", name, "GET", nil, &g, &g)
-	if err != nil {
+	res, err := db.get("gharial", name, "GET", nil, &g, &g)
+	if err != nil || res.Status() != 200 {
 		return nil
 	}
 	// set DB


### PR DESCRIPTION
When invoking Graph() with the name of a non existant graph, the result should be nil.