### PR TITLE
Implemented support for batch saving 

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -154,6 +154,25 @@ func (col *Collection) Save(doc interface{}) error {
 	}
 }
 
+func (col* Collection) BatchSave(docs []interface{}) error {
+	if col.Type != 2 {
+		return errors.New("Trying to save documents into EdgeCollection")
+	}
+	
+	payloads := make([]interface{}, 0, len(docs))
+	results := make([]interface{}, 0, len(docs))
+	errs := make([]interface{}, 0, len(docs))
+	for idx, doc := range docs {
+		payloads = append(payloads, doc)
+		results = append(results, &docs[idx])
+		errs = append(errs, &docs[idx])
+	}
+	
+	// TODO: decode errors
+	_, err := col.db.batchSend("document?collection="+col.Name, "", "POST", payloads, results, errs)	
+	return err
+}
+
 // Save Edge into Edges collection
 func (col *Collection) SaveEdge(doc interface{}, from string, to string) error {
 	var err error
@@ -700,6 +719,8 @@ func (c *Collection) CreateFullText(min int, fields ...string) error {
 	}
 
 	switch res.Status() {
+	case 400:
+		return errors.New("Invalid full-text field or length")	
 	case 404:
 		return errors.New("Collection does not exist")
 	default:

--- a/session.go
+++ b/session.go
@@ -50,7 +50,7 @@ func Connect(host, user, password string, log bool) (*Session, error) {
 	}
 
 	if len(dbs.List) == 0 {
-		return nil, errors.New("Invalid default dabase, no access . Try setting one with : aranGO.SetDefaultDB(db string)")
+		return nil, errors.New("Invalid default database, no access. Try setting one with : aranGO.SetDefaultDB(db string)")
 	}
 
 	sess.dbs.List = dbs.List
@@ -99,7 +99,7 @@ func (s *Session) CurrentDB() (*Database, error) {
 
 	switch res.Status() {
 	case 200:
-		return &db.Db, nil
+		return sdb, nil
 	case 400:
 		return nil, errors.New("Invalid request")
 	case 404:


### PR DESCRIPTION
Saving via db.Col().Save() is quite ineffecient as it requires
http connection per each document and cannot work well for millions
of documents. This issue is addressed with batch requests which
have packed http requests into multipart data.
- Fixed infinite recursion in db.Col() when CreateCollection()
  intermittently fails
- Minor fixes of error recognition and some refactoring
