### PR TITLE
unique check: pass in actual value, not string version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 
 .*
+.wercker

--- a/config_test.go
+++ b/config_test.go
@@ -1,5 +1,11 @@
 package aranGO
 
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
 // Configure to start testing
 var (
 	TestCollection = "TestCollection"
@@ -12,6 +18,16 @@ var (
 	TestServer     = "http://localhost:8529"
 	s              *Session
 )
+
+func init() {
+	if wercker := os.Getenv("WERCKER"); wercker == "true" {
+		log.Printf("Found WERCKER env!")
+		arangoPort := os.Getenv("ARANGODB_PORT_8529_TCP_PORT")
+		arangoIP := os.Getenv("ARANGODB_PORT_8529_TCP_ADDR")
+		TestServer = fmt.Sprintf("http://%s:%s", arangoIP, arangoPort)
+	}
+	log.Printf("using TestServer at %s", TestServer)
+}
 
 // document to test
 type DocTest struct {

--- a/model.go
+++ b/model.go
@@ -255,9 +255,9 @@ func Unique(m interface{}, db *Database, update bool, err Error) {
 				c := db.Col(col)
 				jname := Tag(m, fname, "json")
 				if jname != "" {
-					uniq, _ = c.Unique(jname, field.String(), update, "")
+					uniq, _ = c.Unique(jname, field.Interface(), update, "")
 				} else {
-					uniq, _ = c.Unique(fname, field.String(), update, "")
+					uniq, _ = c.Unique(fname, field.Interface(), update, "")
 				}
 			}
 			if !uniq {
@@ -278,9 +278,9 @@ func unique(m reflect.Value, val map[string]string, db *Database, uniq *bool, up
 				// search by example
 				jname := Tag(m, fname, "json")
 				if jname != "" {
-					*uniq, _ = db.Col(col).Unique(jname, field.String(), update, "")
+					*uniq, _ = db.Col(col).Unique(jname, field.Interface(), update, "")
 				} else {
-					*uniq, _ = db.Col(col).Unique(fname, field.String(), update, "")
+					*uniq, _ = db.Col(col).Unique(fname, field.Interface(), update, "")
 				}
 			}
 			if !*uniq {

--- a/simple_test.go
+++ b/simple_test.go
@@ -2,6 +2,7 @@ package aranGO
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +41,7 @@ func TestSimple(t *testing.T) {
 
 	// Example
 	TestDoc = DocTest{} // Clean TestDoc variable
-  cur, err := c.Example(map[string]interface{}{"Text" : TestString}, 0, 10)
+	cur, err := c.Example(map[string]interface{}{"Text": TestString}, 0, 10)
 	assert.Equal(t, TestDoc.Error, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, cur)
@@ -51,5 +52,4 @@ func TestSimple(t *testing.T) {
 	assert.Equal(t, TestString, TestDoc.Text)
 
 	// need to add new functions!
-
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,27 @@
+box: golang
+services:
+  - id: arangodb
+    env: 
+      ARANGO_NO_AUTH: 1
+build:
+  steps:
+    - install-packages:
+        packages: netcat
+    - setup-go-workspace:
+        package-dir: github.com/diegogub/aranGO
+    - script:
+        name: go get
+        code: |
+          go get -t
+    - script:
+        name: go build
+        code: |
+          go build ./...
+    - script: 
+        name: Wait for Arangodb connection if it is slow
+        code: | 
+          while ! nc -nvz $ARANGODB_PORT_8529_TCP_ADDR $ARANGODB_PORT_8529_TCP_PORT ; do echo "."; sleep 2; done
+    - script:
+        name: go test
+        code: |
+          go test ./...


### PR DESCRIPTION
Hi, 

I was trying to enforce uniqueness on a `int32` field in a model struct using models/context, and it just did not work, without a proper error message. While looking at the mechanism enforcing uniqueness I discovered the example query that is executed in [collection.go:Unique](https://github.com/diegogub/aranGO/blob/master/collection.go#L361) This function gets passed the `String()`ed version of the `reflect.Value`, rather than the underlying value of the field. That might work for strings, but apparently does not for `int` fields. I found two instances where this happens:

* [model.go:Unique](https://github.com/diegogub/aranGO/blob/master/model.go#L258-L260)
* model.go:unique](https://github.com/diegogub/aranGO/blob/master/model.go#L281-L283)

Instead of passing the result of `Value.String()` I propose to pass `Value.Interface()` to make this work for non-string fields as well.