### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/aql2.go
+++ b/aql2.go
@@ -142,7 +142,7 @@ func (q *Query) Modify(query string) error {
 	}
 }
 
-// Validate query before execution
+// MustCheck validates query before execution
 func (q *Query) MustCheck() {
 	q.Validate = true
 	return
@@ -464,7 +464,7 @@ func (aqf AqlFilter) Generate() string {
 	return code
 }
 
-// Returns AqlFilter parsing valid json string
+// FilterJSON returns AqlFilter parsing valid json string
 func FilterJSON(s string) AqlFilter {
 	var aqf AqlFilter
 	json.Unmarshal([]byte(s), &aqf)
@@ -499,7 +499,7 @@ type Filter struct {
 	*/
 }
 
-// Returns filter , comparing with value
+// Fil returns filter , comparing with value
 func Fil(atr string, oper string, i interface{}) Filter {
 	var f Filter
 	f.AtrR = atr
@@ -508,7 +508,7 @@ func Fil(atr string, oper string, i interface{}) Filter {
 	return f
 }
 
-// Returns filter , comparing 2 fields
+// FilField returns filter , comparing 2 fields
 func FilField(atr string, oper string, i string) Filter {
 	var f Filter
 	f.AtrR = atr

--- a/collection.go
+++ b/collection.go
@@ -179,7 +179,7 @@ func (col *Collection) SaveEdge(doc interface{}, from string, to string) error {
 
 }
 
-//Get vertex relations
+//Edges gets vertex relations
 func (col *Collection) Edges(start string, direction string, result interface{}) error {
 	if start == "" {
 		return errors.New("Invalid start vertex")
@@ -329,7 +329,7 @@ func (col *Collection) Delete(key string) error {
 	}
 }
 
-// Get list of collections from any database
+// Collections gets list of collections from any database
 func Collections(db *Database) error {
 	var err error
 	var res *nap.Response
@@ -357,7 +357,7 @@ func Collections(db *Database) error {
 	}
 }
 
-// check if a key is unique
+// Unique checks if a key is unique
 func (c *Collection) Unique(key string, value interface{}, update bool, index string) (bool, error) {
 	var cur *Cursor
 	var err error
@@ -447,7 +447,7 @@ func (c *Collection) Example(doc interface{}, skip, limit int) (*Cursor, error) 
 	}
 }
 
-// Returns first document in example query
+// First returns first document in example query
 func (c *Collection) First(example, doc interface{}) error {
 	var d singleDoc
 	d.Doc = doc
@@ -512,7 +512,7 @@ func (c *Collection) ConditionBitArray(condition string, skip int, limit int, in
 	}
 }
 
-//Return random number
+//Any returns random number
 func (c *Collection) Any(doc interface{}) error {
 	var d singleDoc
 	d.Doc = doc
@@ -530,7 +530,7 @@ func (c *Collection) Any(doc interface{}) error {
 	}
 }
 
-//Get all indexs
+//Indexes gets all indexs
 func (c *Collection) Indexes() (map[string]Index, error) {
 	var indexes Indexes
 	_, err := c.db.get("index?collection="+c.Name, "", "GET", nil, &indexes, &indexes)

--- a/document.go
+++ b/document.go
@@ -30,7 +30,7 @@ func NewDocument(id string) (*Document, error) {
 	return &d, nil
 }
 
-// Return map[string]string of document instead of struct
+// Map returns map[string]string of document instead of struct
 func (d *Document) Map(db *Database) (map[string]string, error) {
 	var m map[string]string
 	sid := strings.Split(d.Id, "/")
@@ -53,7 +53,7 @@ func (d *Document) SetRev(rev string) error {
 	return nil
 }
 
-// Check if a document was updated
+// Updated checks if a document was updated
 func (d *Document) Updated(db *Database) (bool, error) {
 	if db == nil {
 		return false, errors.New("Invalid db")
@@ -79,7 +79,7 @@ func (d *Document) Updated(db *Database) (bool, error) {
 	}
 }
 
-// Check if document exist
+// Exist checks if document exist
 func (d *Document) Exist(db *Database) (bool, error) {
 
 	if db == nil {

--- a/graph.go
+++ b/graph.go
@@ -42,7 +42,7 @@ func (g *Graph) Traverse(t *Traversal, r interface{}) error {
 	}
 }
 
-// Remove Vertex
+// RemoveE removes Vertex
 func (g *Graph) RemoveE(col string, key string) error {
 	if col == "" || key == "" {
 		return errors.New("Invalid key or collection")
@@ -64,7 +64,7 @@ func (g *Graph) RemoveE(col string, key string) error {
 	}
 }
 
-//Replace edge
+//ReplaceE replaces edge
 func (g *Graph) ReplaceE(col string, key string, doc interface{}, patch interface{}) error {
 	if col == "" || key == "" {
 		return errors.New("Invalid key or collection")
@@ -112,7 +112,7 @@ func (g *Graph) PatchE(col string, key string, doc interface{}, patch interface{
 	}
 }
 
-// Get Edge
+// GetE gets Edge
 func (g *Graph) GetE(col string, key string, edge interface{}) error {
 	if col == "" || key == "" {
 		return errors.New("Invalid collection or key value")
@@ -158,7 +158,7 @@ func (g *Graph) E(col string, edge interface{}) error {
 	}
 }
 
-// Remove Vertex
+// RemoveV removes Vertex
 func (g *Graph) RemoveV(col string, key string) error {
 	if col == "" || key == "" {
 		return errors.New("Invalid key or collection")
@@ -180,7 +180,7 @@ func (g *Graph) RemoveV(col string, key string) error {
 	}
 }
 
-//Replace vertex
+//ReplaceV replaces vertex
 func (g *Graph) ReplaceV(col string, key string, doc interface{}, patch interface{}) error {
 	if col == "" || key == "" {
 		return errors.New("Invalid key or collection")
@@ -250,7 +250,7 @@ func (g *Graph) V(col string, doc interface{}) error {
 	}
 }
 
-//Gets Vertex from collection
+//GetV gets Vertex from collection
 func (g *Graph) GetV(col string, key string, doc interface{}) error {
 	if key == "" || col == "" {
 		return errors.New("Invalid key or collection to get")
@@ -276,7 +276,7 @@ func (g *Graph) GetV(col string, key string, doc interface{}) error {
 
 }
 
-// Remove vertex collections
+// RemoveVertexCol removes vertex collections
 func (g *Graph) RemoveVertexCol(col string) error {
 	if g.db == nil {
 		return errors.New("Invalid db")
@@ -300,7 +300,7 @@ func (g *Graph) RemoveVertexCol(col string) error {
 	}
 }
 
-// Remove edge
+// RemoveEdgeDef removes edge
 func (g *Graph) RemoveEdgeDef(col string) error {
 	if g.db == nil {
 		return errors.New("Invalid db")
@@ -324,7 +324,7 @@ func (g *Graph) RemoveEdgeDef(col string) error {
 	}
 }
 
-// Add vertex collections
+// AddVertexCol adds vertex collections
 func (g *Graph) AddVertexCol(col string) error {
 	if g.db == nil {
 		return errors.New("Invalid db")

--- a/replication.go
+++ b/replication.go
@@ -30,7 +30,7 @@ type ReplicationInventory struct {
 	Tick        string           `json:"tick"`
 }
 
-// Returns replication inventory
+// Inventory returns replication inventory
 func (db *Database) Inventory() (*ReplicationInventory, error) {
 	var rinv ReplicationInventory
 

--- a/session.go
+++ b/session.go
@@ -193,7 +193,7 @@ func (s *Session) DropDB(name string) error {
 	}
 }
 
-// Return database
+// DB returns database
 func (s *Session) DB(name string) *Database {
 	var db Database
 	var found bool


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?